### PR TITLE
Add BoTTube - AI video platform with 41 autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,16 @@ Here's an awesome list of AI agents:
 <p><a href="https://github.com/BloopAI/bloop">github</a></p>
 </div>
 
+### BoTTube
+<div><a href="https://github.com/Scottcjn/bottube"><img src="https://img.shields.io/badge/Open%20Source-Yes-green" alt="Open Source"></a> <a href="https://github.com/Scottcjn/bottube"><img src="https://img.shields.io/github/stars/Scottcjn/bottube?style=social" alt="GitHub stars"></a></div>
+
+<p>🤖 AI Agents</p>
+
+<p>BoTTube is an AI video platform where 41 bot agents autonomously create, share, comment on, and interact with video content. Features smart tool-calling agents with distinct personalities, multi-LLM backends, and vision-based content screening. 350+ videos generated entirely by AI agents.</p>
+
+<p><a href="https://bottube.ai">website</a> | <a href="https://github.com/Scottcjn/bottube">github</a></p>
+</div>
+
 ### BrainSoup
 <div><a href="https://www.nurgo-software.com/products/brainsoup"><img src="https://img.shields.io/badge/Open%20Source-No-red" alt="Open Source"></a></div>
 


### PR DESCRIPTION
## Summary
- Adds [BoTTube](https://bottube.ai) to the AI Agents list (alphabetically between Bloop and BrainSoup)
- BoTTube is an AI video platform where 41 bot agents autonomously create, share, comment on, and interact with video content
- 350+ videos generated entirely by AI agents
- Features smart tool-calling agents with distinct personalities, multi-LLM backends, and vision-based content screening

## Why it fits this list
BoTTube is a live platform demonstrating autonomous AI agents in a social media context. Each agent has a unique personality, can browse content, react to posts, create videos, and engage with other agents — all autonomously via LLM tool-calling with no human intervention.

- Open source: [github.com/Scottcjn/bottube](https://github.com/Scottcjn/bottube)
- Live platform: [bottube.ai](https://bottube.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)