### PR TITLE
Add Agent Wallet SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Here's an awesome list of AI agents:
 <p><a href="https://www.aie.foundation/">website</a> | <a href="https://www.aie.foundation/">website</a> | <a href="https://github.com/AI-Engineer-Foundation/agent-protocol">github</a> | <a href="https://github.com/AI-Engineer-Foundation">github profile</a></p>
 </div>
 
+### Agent Wallet SDK
+<div><a href="https://github.com/up2itnow0822/agent-wallet-sdk"><img src="https://img.shields.io/badge/Open%20Source-Yes-green" alt="Open Source"></a> <a href="https://github.com/up2itnow0822/agent-wallet-sdk"><img src="https://img.shields.io/github/stars/up2itnow0822/agent-wallet-sdk?style=social" alt="GitHub stars"></a></div>
+<p>💰 Agent Infrastructure</p>
+
+<p>Non-custodial smart contract wallets built for AI agents. Agents operate as on-chain operators with owner-set daily and per-transaction spend limits — no custodial risk, no key sharing. TypeScript SDK, deployed on Base L2, MIT licensed.</p>
+
+<p><a href="https://github.com/up2itnow0822/agent-wallet-sdk">github</a> | <a href="https://www.npmjs.com/package/agentwallet-sdk">npm</a></p>
+</div>
+
 ### Agent Tools
 <div><a href="https://github.com/aibtcdev/agent-tools-ts"><img src="https://img.shields.io/badge/Open%20Source-Yes-green" alt="Open Source"></a> <a href="https://github.com/aibtcdev/agent-tools-ts"><img src="https://img.shields.io/github/stars/aibtcdev/agent-tools-ts?style=social" alt="GitHub stars"></a></div>
 <p>⭐ 16 stars (Updated: 2025-07-30)</p>


### PR DESCRIPTION
Hey — adding Agent Wallet SDK to the list.

It's an open-source TypeScript SDK for creating non-custodial smart contract wallets that AI agents can actually use. The agent gets an "operator" role with on-chain spend limits (daily + per-tx), so it can transact without ever holding the private key or having unlimited access.

Deployed on Base L2, 267 tests, MIT licensed.

GitHub: https://github.com/up2itnow0822/agent-wallet-sdk
npm: https://www.npmjs.com/package/agentwallet-sdk

Felt like it fits well here — there aren't many wallet-focused agent tools in the list yet.