### PR TITLE
Add Arch Tools — AI agent tool platform with x402 payments

### DIFF
--- a/awesome-agents.yaml
+++ b/awesome-agents.yaml
@@ -2655,3 +2655,19 @@
   categories:
     - "Long-Term Memory"
   
+- project: "Arch Tools"
+  project_description: "The first API platform where AI agents pay per-call with USDC via x402 protocol. 61 production tools including AI generation, web scraping, crypto data, sentiment analysis, OCR, TTS, and more. MCP-compatible — works with Claude Desktop, Cursor, and other MCP clients."
+  project_is_open_source: false
+  sources:
+    - source: "website"
+      source_url: "https://archtools.dev"
+    - source: "github"
+      source_url: "https://github.com/Deesmo/Arch-AI-Tools"
+    - source: "mcp"
+      source_url: "https://arch-tools-mcp.onrender.com/mcp"
+    - source: "x402"
+      source_url: "https://archtools.dev/.well-known/x402"
+  categories:
+    - "AI Agents"
+    - "Developer Tools"
+    - "Crypto"


### PR DESCRIPTION
Adds Arch Tools to the awesome agents list.

**Arch Tools** is the first API platform where AI agents pay per-call with USDC via the x402 protocol. 61 production tools spanning AI, web, crypto, utilities, and more.

- **Website**: https://archtools.dev
- **MCP Server**: https://arch-tools-mcp.onrender.com/mcp
- **x402 Discovery**: https://archtools.dev/.well-known/x402
- **Registered on x402scan**: 61/61 resources
- **Networks**: Base, Polygon, Avalanche, Solana (USDC)