### PR TITLE
Add MemClaw — persistent project memory for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1653,6 +1653,15 @@ Here's an awesome list of AI agents:
 <p><a href="https://github.com/mem0ai/mem0">github</a> | <a href="https://app.mem0.ai/">website</a> | <a href="https://docs.mem0.ai/">docs</a> | <a href="https://mem0.ai/discord">discord</a> | <a href="https://x.com/mem0ai">twitter</a> | <a href="https://github.com/mem0ai">github profile</a> | <a href="https://www.linkedin.com/company/mem0/">linkedin</a></p>
 </div>
 
+### MemClaw
+<div><a href="https://github.com/Felo-Inc/memclaw"><img src="https://img.shields.io/badge/Open%20Source-Yes-green" alt="Open Source"></a> <a href="https://github.com/Felo-Inc/memclaw"><img src="https://img.shields.io/github/stars/Felo-Inc/memclaw?style=social" alt="GitHub stars"></a></div>
+<p>🧠 Long-Term Memory</p>
+
+<p>MemClaw provides persistent project memory for AI coding agents with per-project isolation, giving each project its own memory workspace with a web dashboard for reviewing and managing what your AI remembers. Free to use, MIT licensed, MCP-compatible.</p>
+
+<p><a href="https://github.com/Felo-Inc/memclaw">github</a> | <a href="https://memclaw.me">website</a></p>
+</div>
+
 ### MemGPT
 <div><a href="https://github.com/cpacker/MemGPT/"><img src="https://img.shields.io/badge/Open%20Source-Yes-green" alt="Open Source"></a> <a href="https://github.com/cpacker/MemGPT/"><img src="https://img.shields.io/github/stars/cpacker/MemGPT?style=social" alt="GitHub stars"></a></div>
 <p>⭐ 17,568 stars (Updated: 2025-07-30)</p>

--- a/awesome-agents.json
+++ b/awesome-agents.json
@@ -1207,6 +1207,24 @@
       ]
     },
     {
+      "project": "MemClaw",
+      "project_description": "MemClaw provides persistent project memory for AI coding agents with per-project isolation, giving each project its own memory workspace with a web dashboard for reviewing and managing what your AI remembers. Free to use, MIT licensed, MCP-compatible.",
+      "project_is_open_source": true,
+      "sources": [
+        {
+          "source": "github",
+          "source_url": "https://github.com/Felo-Inc/memclaw"
+        },
+        {
+          "source": "website",
+          "source_url": "https://memclaw.me"
+        }
+      ],
+      "categories": [
+        "Long-Term Memory"
+      ]
+    },
+    {
       "project": "MemGPT",
       "project_description": "MemGPT introduces a customizable AI chatbot framework with self-editing memory and access to unlimited data, promoting perpetual, context-rich conversations",
       "project_is_open_source": true,

--- a/awesome-agents.yaml
+++ b/awesome-agents.yaml
@@ -698,6 +698,17 @@
   categories:
     - "Build Club"
 
+- project: "MemClaw"
+  project_description: "MemClaw provides persistent project memory for AI coding agents with per-project isolation, giving each project its own memory workspace with a web dashboard for reviewing and managing what your AI remembers. Free to use, MIT licensed, MCP-compatible."
+  project_is_open_source: true
+  sources:
+    - source: "github"
+      source_url: "https://github.com/Felo-Inc/memclaw"
+    - source: "website"
+      source_url: "https://memclaw.me"
+  categories:
+    - "Long-Term Memory"
+
 - project: "MemGPT"
   project_description: "MemGPT introduces a customizable AI chatbot framework with self-editing memory and access to unlimited data, promoting perpetual, context-rich conversations"
   project_is_open_source: true


### PR DESCRIPTION
Hi @slavakurilyak, I'm adding MemClaw to the Long-Term Memory category.

**MemClaw** ([GitHub](https://github.com/Felo-Inc/memclaw) | [Website](https://memclaw.me)) is a persistent project memory tool for AI coding agents. Key differentiator: per-project memory isolation — each project gets its own memory workspace, preventing context bleed between projects. Features a web dashboard for reviewing/managing memories, MCP-compatible, and free to use (MIT).

Updated `awesome-agents.yaml`, `awesome-agents.json`, and `README.md` to maintain consistency.