### PR TITLE
Add Hermes Plant — agent action safety and commerce assurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,16 @@ Here's an awesome list of AI agents:
 <p><a href="https://www.helicone.ai/">website</a> | <a href="https://github.com/Helicone/helicone">github</a></p>
 </div>
 
+### Hermes Plant
+<div><a href="https://hermesplant.com/"><img src="https://img.shields.io/badge/Hosted-Yes-blue" alt="Hosted Service"></a> <a href="https://hermesplant.com/changelog"><img src="https://img.shields.io/badge/Changelog-Live-success" alt="Changelog"></a></div>
+<p>⭐ Hosted service (Updated: 2026-06-26)</p>
+<p>💰 Finance & Quant APIs for AI Agents</p>
+
+<p>Deterministic finance and quant APIs that AI agents call and pay for per call over x402 — DCF, IRR, LP/GP waterfalls, Black-Scholes Greeks, bond analytics, portfolio risk, and AML screening. Also exposes an MCP server. No API keys, no data feeds, no hallucinated math.</p>
+
+<p><a href="https://hermesplant.com/">website</a> | <a href="https://hermesplant.com/mcp">mcp endpoint</a> | <a href="https://hermesplant.com/llms.txt">llms.txt</a> | <a href="https://hermesplant.com/changelog">changelog</a></p>
+</div>
+
 ### Humane
 <div><a href="https://humane.com/"><img src="https://img.shields.io/badge/Open%20Source-No-red" alt="Open Source"></a></div>
 

--- a/README.md
+++ b/README.md
@@ -1274,13 +1274,13 @@ Here's an awesome list of AI agents:
 </div>
 
 ### Hermes Plant
-<div><a href="https://hermesplant.com/"><img src="https://img.shields.io/badge/Hosted-Yes-blue" alt="Hosted Service"></a> <a href="https://hermesplant.com/changelog"><img src="https://img.shields.io/badge/Changelog-Live-success" alt="Changelog"></a></div>
-<p>⭐ Hosted service (Updated: 2026-06-26)</p>
-<p>💰 Finance & Quant APIs for AI Agents</p>
+<div><a href="https://hermesplant.com/"><img src="https://img.shields.io/badge/Hosted-Yes-blue" alt="Hosted Service"></a> <a href="https://github.com/JesseGdotIO/hermesplant-mcp-server"><img src="https://img.shields.io/badge/MCP-Open%20Source-green" alt="Open Source MCP Server"></a></div>
+<p>⭐ Hosted service (Updated: 2026-07-28)</p>
+<p>🛡️ Agent Action Safety & Commerce Assurance</p>
 
-<p>Deterministic finance and quant APIs that AI agents call and pay for per call over x402 — DCF, IRR, LP/GP waterfalls, Black-Scholes Greeks, bond analytics, portfolio risk, and AML screening. Also exposes an MCP server. No API keys, no data feeds, no hallucinated math.</p>
+<p>Preflight consequential agent actions, route approvals, enforce spend policy, and produce signed evidence across shell, Git, SQL, deploy, and x402 workflows. Available as a hosted Streamable HTTP MCP server and REST API, with a free API-key tier or USDC pay-per-call access over x402.</p>
 
-<p><a href="https://hermesplant.com/">website</a> | <a href="https://hermesplant.com/mcp">mcp endpoint</a> | <a href="https://hermesplant.com/llms.txt">llms.txt</a> | <a href="https://hermesplant.com/changelog">changelog</a></p>
+<p><a href="https://hermesplant.com/agent-services">website</a> | <a href="https://mcp.hermesplant.com/mcp">mcp endpoint</a> | <a href="https://github.com/JesseGdotIO/hermesplant-mcp-server">github</a> | <a href="https://hermesplant.com/.well-known/x402">x402 manifest</a></p>
 </div>
 
 ### Humane


### PR DESCRIPTION
Adds Hermes Plant under All Projects (alphabetically between Helicone and Humane).

Hermes Plant provides action safety and commerce assurance for AI agents: preflight consequential shell/Git/SQL/deploy/x402 actions, route approvals, enforce spend policy, and produce signed evidence. It is available as a hosted Streamable HTTP MCP server and REST API, with a free API-key tier or USDC pay-per-call access over x402.

Canonical public surfaces:
- MCP source: https://github.com/JesseGdotIO/hermesplant-mcp-server
- Hosted MCP: https://mcp.hermesplant.com/mcp
- x402 manifest: https://hermesplant.com/.well-known/x402
- Agent services: https://hermesplant.com/agent-services

The entry follows the existing badge, description, and links pattern and was refreshed on 2026-07-28.